### PR TITLE
update options type

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -204,7 +204,7 @@ export interface ProTableProps<T, U extends { [key: string]: any }>
   /**
    * 默认的操作栏配置
    */
-  options?: OptionConfig<T>;
+  options?: OptionConfig<T> | false;
   /**
    * 是否显示搜索表单
    */


### PR DESCRIPTION
According to the API docs, we can set `options: false` to hide all these options. When I set options to false, below error shows.

`
options
Type 'false' is not assignable to type 'OptionConfig<TableListItem> | undefined'.ts(2322)
Table.d.ts(145, 5): The expected type comes from property 'options' which is declared here on type 'IntrinsicAttributes & ProTableProps<TableListItem, {}>'`