### PR TITLE
bugfix: dark theme title color

### DIFF
--- a/src/component/toolBar/index.less
+++ b/src/component/toolBar/index.less
@@ -31,7 +31,7 @@
 
     &-title {
       flex: 1;
-      color: #000;
+      color: @label-color;
       font-size: 16px;
       line-height: 24px;
       opacity: 0.85;


### PR DESCRIPTION
修复dark模式下 title颜色为黑色的问题

修改前
![image](https://user-images.githubusercontent.com/7540584/75994319-c0c0fd00-5f35-11ea-8750-174ab674ec1c.png)


修改后
![image](https://user-images.githubusercontent.com/7540584/75994008-4d1ef000-5f35-11ea-98fa-aa2926d805c9.png)
