### PR TITLE
🐛 bug:fix the status white screen with valueEnmu misconfiguration

### DIFF
--- a/src/component/util.tsx
+++ b/src/component/util.tsx
@@ -39,7 +39,9 @@ export const parsingText = (
     }
     const { status } = domText;
     const Status = TableStatus[status || 'Init'];
-    return <Status>{domText.text}</Status>;
+    if (Status) {
+      return <Status>{domText.text}</Status>;
+    }
   }
   return domText.text || domText;
 };


### PR DESCRIPTION
```
 {
      title: '性别',
      dataIndex: 'sex',
      valueEnum: {
        1: { text: '女', status: '1' },
        2: { text: '男', status: '2' },
        3: { text: '未知', status: '3' },
      },
    },
```