### PR TITLE
feat(useFetchData): 增加错误抛出

### DIFF
--- a/src/useFetchData.tsx
+++ b/src/useFetchData.tsx
@@ -42,12 +42,8 @@ const useFetchData = <T extends RequestData<any>>(
   },
 ): UseFetchDataAction<T> => {
   let isMount = true;
-  const {
-    defaultPageSize = 20,
-    defaultCurrent = 1,
-    onLoad = () => null,
-    onRequestError = () => null,
-  } = options || {};
+  const { defaultPageSize = 20, defaultCurrent = 1, onLoad = () => null, onRequestError } =
+    options || {};
 
   const [list, setList] = useState<T['data']>(defaultData as any);
   const [loading, setLoading] = useState<boolean | undefined>(undefined);
@@ -95,7 +91,12 @@ const useFetchData = <T extends RequestData<any>>(
         onLoad(data);
       }
     } catch (e) {
-      onRequestError(e);
+      // 如果没有传递这个方法的话，需要把错误抛出去，以免吞掉错误
+      if (onRequestError === undefined) {
+        throw new Error(e);
+      } else {
+        onRequestError(e);
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
onRequestError 这个方法不是必传的参数，在没有传递这个参数的时候，如果在请求数据和数据处理过程中，出现问题，比如调用了错误的方法，错误会被吞并，导致难以定位问题。