### PR TITLE
🐛 bug: remove extraneous space for FormOption

### DIFF
--- a/src/form/FormOption.tsx
+++ b/src/form/FormOption.tsx
@@ -50,7 +50,7 @@ const FormOption: React.FC<FormOptionProps> = (props) => {
         }}
       >
         {resetText}
-      </Button>{' '}
+      </Button>
       <Button type="primary" htmlType="submit" onClick={() => submit()}>
         {isForm ? submitText : searchText}
       </Button>


### PR DESCRIPTION
`<Space>` component already puts some space between the buttons. Putting a blank character doubles the space between the submit and reset buttons.