### PR TITLE
fix:表头合并导致筛选项丢失，展开表头

### DIFF
--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -576,6 +576,19 @@ const getSpanConfig = (
   return config[size];
 };
 
+/**
+ * 分组表头需要展开
+ */
+const expandProColumns = (proColumns: any, defaultColumns: any[] = []): ProColumns<any>[] => {
+  const columns = defaultColumns;
+  proColumns.map((i) => {
+    if (Array.isArray(i.children)) expandProColumns(i.children, columns);
+    else columns.push(i);
+    return null;
+  });
+  return columns;
+};
+
 const FormSearch = <T, U = {}>({
   onSubmit,
   formRef,
@@ -658,13 +671,13 @@ const FormSearch = <T, U = {}>({
 
   useDeepCompareEffect(() => {
     const tempMap = {};
-    counter.proColumns.forEach((item) => {
+    expandProColumns(counter.proColumns).forEach((item) => {
       tempMap[genColumnKey(item.key, item.dataIndex, item.index) || 'null'] = item;
     });
     setProColumnsMap(tempMap);
   }, [counter.proColumns]);
 
-  const columnsList = counter.proColumns
+  const columnsList = expandProColumns(counter.proColumns)
     .filter((item) => {
       const { valueType } = item;
       if (item.hideInSearch && type !== 'form') {


### PR DESCRIPTION
[合并表头，查询表单中合并的筛选项会丢失](https://github.com/ant-design/pro-table/issues/611)
添加表头展开方法，作用于columnsList设置和proColumnsMap