### PR TITLE
fix the problem of ProTable missing sort value

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -598,6 +598,35 @@ const ProTable = <T extends {}, U extends object>(
     columnEmptyText = '-',
     ...rest
   } = props;
+            
+  /**
+   * 获得默认排序的字段;
+   * 为了解决[字段同时为'默认不展示'与'默认排序'时, 导致排序失效]的问题;
+   * 只需要渲染一次即可;
+   */
+  useEffect(() => {
+    // 取出默认排序的字段
+    const items: ProColumns<T>[] =
+      propsColumns.filter((item) => item.defaultSortOrder !== undefined && item.defaultSortOrder != null)
+
+    if (items.length > 0) {
+      const convertOrder = {
+        "ascend": 'ascend',
+        "descend": 'descend',
+      }
+      const data =
+        items.reduce<{ [key: string]: any; }>((pre, value) => {
+          if (!value.defaultSortOrder) {
+            return pre;
+          }
+          return {
+            ...pre,
+            [`${value.dataIndex}`]: convertOrder[value.defaultSortOrder],
+          };
+        }, {});
+      setProSort(data);
+    }
+  }, []);
 
   const [selectedRowKeys, setSelectedRowKeys] = useMergeValue<React.ReactText[]>([], {
     value: propsRowSelection ? propsRowSelection.selectedRowKeys : undefined,


### PR DESCRIPTION

### 问题描述

> 当且仅当, 
> 字段同时设置了`defaultSortOrder`默认排序与`columnsStateMap`默认不展示时,
> `ProTable`传参给`Table`的`columns`会过滤不展示字段, 这也使得排序信息丢失,
> 导致, `onChange`时`sorter`值缺失.
> 同理, 'Filter'的工作原理与'Sort'相似, 应该存在同样的问题.

本次提交, 解决[字段同时为'默认不展示'与'默认排序'时, 导致排序失效]的问题.
但是没有修改`Filter`的传参问题, 有兴趣的同学可以关注下.

<br />

`ps. 本人不是前端开发者😅, 代码写的比较粗糙, 各位大牛多多指点`